### PR TITLE
Fix matching organisation name to repo name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -95,7 +95,7 @@ runs:
         echo "pr=$pr" >> "$GITHUB_ENV"
 
         org=$(echo "$GITHUB_REPOSITORY" | cut -d "/" -f 1)
-        thirdleveldomain=$(echo "$GITHUB_REPOSITORY" | cut -d "/" -f 2 | cut -d "." -f 1)
+        thirdleveldomain=$(echo "$GITHUB_REPOSITORY" | cut -d "/" -f 2 | tr '[:upper:]' '[:lower:]' )
 
         if [ "$org" == "$thirdleveldomain" ]; then
           pagesurl="${org}.github.io"

--- a/lib/find-current-git-tag.sh
+++ b/lib/find-current-git-tag.sh
@@ -26,9 +26,7 @@ git clone --bare --single-branch --branch "$git_ref" "https://github.com/$github
 
 cd bare_pr_preview || exit 1
 
-action_version=$(git describe --tags --match "v*.*.*" \
-  || git describe --tags \
-  || git rev-parse HEAD)
+action_version=$(git describe --tags || git rev-parse HEAD)
 
 echo "$action_version"
 exit 0


### PR DESCRIPTION
Make case-insensitive comparison between organisation name and repo name.

Closes #5 